### PR TITLE
Avoid unnecessarily emitting 'next' during authentication

### DIFF
--- a/flatiron-passport.js
+++ b/flatiron-passport.js
@@ -49,7 +49,7 @@ exports.authenticate = function(name, options, callback) {
     passport.authenticate(name, options, callback)(this.req, this.res, (function(self) {
       return function(cb) {
         if (typeof self.cb === 'function') {
-          self.cb();
+          return self.cb();
         }
         self.res.emit('next');
       }


### PR DESCRIPTION
I think I found and fixed a bug in the `authenticate()` function.

I am using MongoDB to store and retrieve session ids, that are used with [oauth2orize](//github.com/jaredhanson/oauth2orize). The entire setup is too complex to be described here. Long story short, when I had some truly asynchronous calls before a response was generated, an exception was thrown.

When I change your code to return after making the callback (see the [diff](https://github.com/pvorb/flatiron-passport/commit/ad41b40cad1a56e6da6953c13c6a46e9d8109c34)) and thus avoid to emit `'next'`, that bug doesn't occur anymore.

Could you please check if this breaks any existing behavior and, if it doesn't, merge the pull request and update the npm package? This change is crucial to the application I'm working on.
